### PR TITLE
🔧 Give context scraper more power

### DIFF
--- a/scraper/serverless.yml
+++ b/scraper/serverless.yml
@@ -49,6 +49,7 @@ functions:
     scrapeContext:
         handler: src/index.scrapeContext
         timeout: 900
+        memorySize: 2048
         events:
             - schedule:
                   name: ${self:service}-${self:provider.stage}-scrapeContext


### PR DESCRIPTION
It's dangerously close to the 15 minutes max timeout, maybe some more
CPU budget will help